### PR TITLE
Tile placeholde

### DIFF
--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 
 import 'tile_placeholder_painter.dart';
 
+///A placeholder that draws a faint grid on the tiles that are loading tile images. 
+///It helps with indication of the tile loading process.
 class TilePlaceholder extends StatelessWidget {
   const TilePlaceholder({super.key});
 
   @override
   Widget build(BuildContext context) {
     return const LimitedBox(
-       maxWidth: 400,
+      maxWidth: 400,
       maxHeight: 400,
       child: CustomPaint(
         size: Size.infinite,

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+import 'tile_placeholder_painter.dart';
+
+class TilePlaceholder extends StatelessWidget {
+  const TilePlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const LimitedBox(
+       maxWidth: 400,
+      maxHeight: 400,
+      child: CustomPaint(
+        size: Size.infinite,
+        painter: TilePlaceholderPainter(
+          color: Colors.white,
+          strokeWidth: 1,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
@@ -12,7 +12,7 @@ class TilePlaceholderPainter extends CustomPainter {
 
 void _drawGrid(Canvas canvas, Size size) {
     final Paint paint = Paint()
-      ..color = color.withOpacity(0.5)
+      ..color = color.withOpacity(0.1)
       ..style = PaintingStyle.stroke
       ..strokeWidth = strokeWidth;
    for (double i = 0; i <= size.width; i += size.width / 9) {

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
@@ -38,9 +38,9 @@ void _drawGrid(Canvas canvas, Size size) {
   }
 
   @override
-  bool shouldRepaint(TilePlaceholderPainter oldPainter) {
-    return oldPainter.color != color
-        || oldPainter.strokeWidth != strokeWidth;
+  bool shouldRepaint(TilePlaceholderPainter oldDelegate) {
+    return oldDelegate.color != color
+        || oldDelegate.strokeWidth != strokeWidth;
   }
 
   @override

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
@@ -10,24 +10,28 @@ class TilePlaceholderPainter extends CustomPainter {
   final Color color;
   final double strokeWidth;
 
-void _drawGrid(Canvas canvas, Size size) {
+  ///Drawing horizontal and vertical lines to create a grid where first and last lines are drawn with a thicker stroke.
+  void _drawGrid(Canvas canvas, Size size) {
     final Paint paint = Paint()
       ..color = color.withOpacity(0.1)
       ..style = PaintingStyle.stroke
       ..strokeWidth = strokeWidth;
-   for (double i = 0; i <= size.width; i += size.width / 9) {
-    if (i == 0 || i >= size.width) {
-      canvas.drawLine(Offset(i, 0), Offset(i, size.height), paint..strokeWidth = strokeWidth + 2);
-    }else{
-      canvas.drawLine(Offset(i, 0), Offset(i, size.height), paint..strokeWidth = strokeWidth);
-    }
-      
+    for (double i = 0; i <= size.width; i += size.width / 9) {
+      if (i == 0 || i >= size.width) {
+        canvas.drawLine(Offset(i, 0), Offset(i, size.height),
+            paint..strokeWidth = strokeWidth + 2);
+      } else {
+        canvas.drawLine(Offset(i, 0), Offset(i, size.height),
+            paint..strokeWidth = strokeWidth);
+      }
     }
     for (double i = 0; i <= size.height; i += size.height / 9) {
       if (i == 0 || i >= size.height) {
-        canvas.drawLine(Offset(0, i), Offset(size.width, i), paint..strokeWidth = strokeWidth + 2);
-      }else{
-        canvas.drawLine(Offset(0, i), Offset(size.width, i), paint..strokeWidth = strokeWidth);
+        canvas.drawLine(Offset(0, i), Offset(size.width, i),
+            paint..strokeWidth = strokeWidth + 2);
+      } else {
+        canvas.drawLine(Offset(0, i), Offset(size.width, i),
+            paint..strokeWidth = strokeWidth);
       }
     }
   }
@@ -39,8 +43,7 @@ void _drawGrid(Canvas canvas, Size size) {
 
   @override
   bool shouldRepaint(TilePlaceholderPainter oldDelegate) {
-    return oldDelegate.color != color
-        || oldDelegate.strokeWidth != strokeWidth;
+    return oldDelegate.color != color || oldDelegate.strokeWidth != strokeWidth;
   }
 
   @override

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+///Draws a Rectangular grid lines on the tile
+class TilePlaceholderPainter extends CustomPainter {
+  const TilePlaceholderPainter({
+    required this.color,
+    required this.strokeWidth,
+  });
+
+  final Color color;
+  final double strokeWidth;
+
+void _drawGrid(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = color.withOpacity(0.5)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth;
+   for (double i = 0; i <= size.width; i += size.width / 9) {
+    if (i == 0 || i >= size.width) {
+      canvas.drawLine(Offset(i, 0), Offset(i, size.height), paint..strokeWidth = strokeWidth + 2);
+    }else{
+      canvas.drawLine(Offset(i, 0), Offset(i, size.height), paint..strokeWidth = strokeWidth);
+    }
+      
+    }
+    for (double i = 0; i <= size.height; i += size.height / 9) {
+      if (i == 0 || i >= size.height) {
+        canvas.drawLine(Offset(0, i), Offset(size.width, i), paint..strokeWidth = strokeWidth + 2);
+      }else{
+        canvas.drawLine(Offset(0, i), Offset(size.width, i), paint..strokeWidth = strokeWidth);
+      }
+    }
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    _drawGrid(canvas, size);
+  }
+
+  @override
+  bool shouldRepaint(TilePlaceholderPainter oldPainter) {
+    return oldPainter.color != color
+        || oldPainter.strokeWidth != strokeWidth;
+  }
+
+  @override
+  bool hitTest(Offset position) => false;
+}

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/src/layer/tile_layer/placeholder/tile_placeholder.dart';
 
 /// The widget for a single tile used for the [TileLayer].
 @immutable
@@ -20,7 +19,7 @@ class Tile extends StatefulWidget {
   final Point<double> currentPixelOrigin;
 
   ///A placeholder widget to be shown while the tile is loading
-  final Widget? placeHolder;
+  final Widget? placeholder;
 
   /// Creates a new instance of [Tile].
   const Tile({
@@ -29,7 +28,7 @@ class Tile extends StatefulWidget {
     required this.currentPixelOrigin,
     required this.tileImage,
     required this.tileBuilder,
-    this.placeHolder,
+    this.placeholder,
   });
 
   @override
@@ -53,11 +52,8 @@ class _TileState extends State<Tile> {
     if (mounted) setState(() {});
   }
 
-
   @override
   Widget build(BuildContext context) {
-     //Add postFrameCallback
-
     return Positioned(
       left: widget.tileImage.coordinates.x * widget.scaledTileSize -
           widget.currentPixelOrigin.x,
@@ -65,15 +61,13 @@ class _TileState extends State<Tile> {
           widget.currentPixelOrigin.y,
       width: widget.scaledTileSize,
       height: widget.scaledTileSize,
-      child: widget.tileBuilder?.call(context, _tileImage, widget.tileImage) ?? _tileImage,
+      child: widget.tileBuilder?.call(context, _tileImage, widget.tileImage) ??
+          _tileImage,
     );
   }
 
- 
-
   Widget get _tileImage {
     if (widget.tileImage.loadError && widget.tileImage.errorImage != null) {
-      print('Tile load error: ${widget.tileImage.errorImage}');
       return Image(
         image: widget.tileImage.errorImage!,
         opacity: widget.tileImage.opacity == 1
@@ -81,7 +75,6 @@ class _TileState extends State<Tile> {
             : AlwaysStoppedAnimation(widget.tileImage.opacity),
       );
     } else if (widget.tileImage.animation == null) {
-      print('Tile image animation null: ${widget.tileImage.imageInfo?.image}');
       return RawImage(
         image: widget.tileImage.imageInfo?.image,
         fit: BoxFit.fill,
@@ -89,11 +82,10 @@ class _TileState extends State<Tile> {
             ? null
             : AlwaysStoppedAnimation(widget.tileImage.opacity),
       );
-    } 
-    else{
-      print('Tile image: ${widget.tileImage.imageInfo?.image}');
-      return 
-      AnimatedBuilder(
+    } else if (!widget.tileImage.readyToDisplay) {
+      return widget.placeholder ?? Container();
+    } else {
+      return AnimatedBuilder(
         animation: widget.tileImage.animation!,
         builder: (context, child) => RawImage(
           image: widget.tileImage.imageInfo?.image,

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/layer/tile_layer/placeholder/tile_placeholder.dart';
 
 /// The widget for a single tile used for the [TileLayer].
 @immutable
@@ -18,6 +19,9 @@ class Tile extends StatefulWidget {
 
   final Point<double> currentPixelOrigin;
 
+  ///A placeholder widget to be shown while the tile is loading
+  final Widget? placeHolder;
+
   /// Creates a new instance of [Tile].
   const Tile({
     super.key,
@@ -25,6 +29,7 @@ class Tile extends StatefulWidget {
     required this.currentPixelOrigin,
     required this.tileImage,
     required this.tileBuilder,
+    this.placeHolder,
   });
 
   @override
@@ -48,8 +53,11 @@ class _TileState extends State<Tile> {
     if (mounted) setState(() {});
   }
 
+
   @override
   Widget build(BuildContext context) {
+     //Add postFrameCallback
+
     return Positioned(
       left: widget.tileImage.coordinates.x * widget.scaledTileSize -
           widget.currentPixelOrigin.x,
@@ -57,13 +65,15 @@ class _TileState extends State<Tile> {
           widget.currentPixelOrigin.y,
       width: widget.scaledTileSize,
       height: widget.scaledTileSize,
-      child: widget.tileBuilder?.call(context, _tileImage, widget.tileImage) ??
-          _tileImage,
+      child: widget.tileBuilder?.call(context, _tileImage, widget.tileImage) ?? _tileImage,
     );
   }
 
+ 
+
   Widget get _tileImage {
     if (widget.tileImage.loadError && widget.tileImage.errorImage != null) {
+      print('Tile load error: ${widget.tileImage.errorImage}');
       return Image(
         image: widget.tileImage.errorImage!,
         opacity: widget.tileImage.opacity == 1
@@ -71,6 +81,7 @@ class _TileState extends State<Tile> {
             : AlwaysStoppedAnimation(widget.tileImage.opacity),
       );
     } else if (widget.tileImage.animation == null) {
+      print('Tile image animation null: ${widget.tileImage.imageInfo?.image}');
       return RawImage(
         image: widget.tileImage.imageInfo?.image,
         fit: BoxFit.fill,
@@ -78,8 +89,11 @@ class _TileState extends State<Tile> {
             ? null
             : AlwaysStoppedAnimation(widget.tileImage.opacity),
       );
-    } else {
-      return AnimatedBuilder(
+    } 
+    else{
+      print('Tile image: ${widget.tileImage.imageInfo?.image}');
+      return 
+      AnimatedBuilder(
         animation: widget.tileImage.animation!,
         builder: (context, child) => RawImage(
           image: widget.tileImage.imageInfo?.image,

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -82,8 +82,8 @@ class _TileState extends State<Tile> {
             ? null
             : AlwaysStoppedAnimation(widget.tileImage.opacity),
       );
-    } else if (!widget.tileImage.readyToDisplay) {
-      return widget.placeholder ?? Container();
+    } else if (widget.tileImage.imageInfo == null) {
+      return widget.placeholder!;
     } else {
       return AnimatedBuilder(
         animation: widget.tileImage.animation!,

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -82,7 +82,7 @@ class _TileState extends State<Tile> {
             ? null
             : AlwaysStoppedAnimation(widget.tileImage.opacity),
       );
-    } else if (widget.tileImage.imageInfo == null) {
+    } else if (widget.tileImage.imageInfo == null && widget.placeholder != null) {
       return widget.placeholder!;
     } else {
       return AnimatedBuilder(

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -209,18 +209,24 @@ class TileLayer extends StatefulWidget {
   /// no affect.
   final TileUpdateTransformer tileUpdateTransformer;
 
-  /// Defines the minimum delay time from last map event before the tile layers are updated.
+  /// Defines the minimum delay time from last map event before the tile layers
+  /// are updated. This delay acts as a debounce period to prevent frequent
+  /// reloading of tile layers in response to rapid, successive events
+  /// (e.g., zooming or panning).
   ///
-  /// 16ms could be a good starting point for most applications. This at 60fps this will wait one frame after the last event.
+  /// 16ms could be a good starting point for most applications.
+  /// This at 60fps this will wait one frame after the last event.
   ///
-  /// This delay acts as a debounce period to prevent frequent reloading of tile layers in response to rapid, successive events (e.g., zooming or panning).
+  /// By setting this delay, we ensure that map layer updates are performed
+  /// only after a period of inactivity, enhancing performance and user
+  /// experience on lower performance devices.
   ///
-  /// By setting this delay, we ensure that map layer updates are performed only after a period of inactivity, enhancing performance and user experience on lower performance devices.
-  ///
-  /// - If multiple events occur within this delay period, only the last event triggers the tile layer update, reducing unnecessary processing and network requests.
-  ///
-  /// - If the [loadingDelay] is `null`, the tile layers will update as soon as possible.
-  final Duration? loadingDelay;
+  /// - If multiple events occur within this delay period, only the last event
+  ///   triggers the tile layer update, reducing unnecessary processing and
+  ///   network requests.
+  /// - If the [loadingDelay] is `Duration.zero`, the delay is completely
+  /// disabled and the tile layer will update as soon as possible.
+  final Duration loadingDelay;
 
   /// Create a new [TileLayer] for the [FlutterMap] widget.
   TileLayer({
@@ -253,7 +259,7 @@ class TileLayer extends StatefulWidget {
     this.evictErrorTileStrategy = EvictErrorTileStrategy.none,
     this.reset,
     this.tileBounds,
-    this.loadingDelay,
+    this.loadingDelay = Duration.zero,
     TileUpdateTransformer? tileUpdateTransformer,
     String userAgentPackageName = 'unknown',
   })  : assert(
@@ -348,6 +354,9 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       TileRangeCalculator(tileSize: widget.tileSize);
   late TileScaleCalculator _tileScaleCalculator;
 
+  /// Delay Timer for [TileLayer.loadingDelay]
+  Timer? _delayTimer;
+
   // We have to hold on to the mapController hashCode to determine whether we
   // need to reinitialize the listeners. didChangeDependencies is called on
   // every map movement and if we unsubscribe and resubscribe every time we
@@ -362,27 +371,22 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     _loadAndPruneInVisibleBounds(MapCamera.of(context));
   });
 
-  /// Delay Timer for loadingDelay
-  Timer? _delayTimer;
-
-  /// This method is used to delay the execution of a function by the specified [loadingDelay].
-  /// This is useful to prevent frequent reloading of tile layers in response to rapid, successive events (e.g., zooming or panning).
-  void _loadingDelay(void Function() action) {
-    //execute immediately if delay is not provided.
-    if (widget.loadingDelay == null) {
+  /// This method is used to delay the execution of a function by the specified
+  /// [TileLayer.loadingDelay]. This is useful to prevent frequent reloading
+  /// of tile layers in response to rapid, successive events (e.g., zooming
+  /// or panning).
+  void _loadingDelay(VoidCallback action) {
+    //execute immediately if delay is zero.
+    if (widget.loadingDelay == Duration.zero) {
       action();
       return;
     }
 
-    // Cancel the previous timer if it is still active
-    if (_delayTimer?.isActive ?? false) {
-      _delayTimer!.cancel();
-    }
+    // Cancel the previous timer if it is still active.
+    _delayTimer?.cancel();
 
     // Reset the timer to wait for the debounce duration
-    _delayTimer = Timer(widget.loadingDelay!, () {
-      action();
-    });
+    _delayTimer = Timer(widget.loadingDelay, action);
   }
 
   // This is called on every map movement so we should avoid expensive logic
@@ -550,7 +554,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               ),
               currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
-              placeholder: !tileImage.readyToDisplay ? const TilePlaceholder() : null,
+              placeholder: const TilePlaceholder(),
               tileBuilder: widget.tileBuilder,
             ))
         .toList();

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart' show MapEquality;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/layer/tile_layer/placeholder/tile_placeholder.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart';
@@ -551,6 +552,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               ),
               currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
+              placeHolder: tileImage.imageInfo == null ? TilePlaceholder() : null,
               tileBuilder: widget.tileBuilder,
             ))
         .toList();

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -231,7 +231,9 @@ class TileLayer extends StatefulWidget {
   /// If `true`, a placeholder grid will be shown on the tiles that are loading.
   /// It helps with indication of the tile loading process and in case when no tiles are loaded can indicate that app is responsive rather than see a blank gay screen.
   /// If `false`, no placeholder grid will be shown.
+  /// 
   /// If `true` and [placeholder] is not set, a default grid will be shown.
+  /// 
   /// If `true` and [placeholder] is set, the [placeholder] will be shown instead.
   final bool showPlaceholder;
 

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -210,7 +210,7 @@ class TileLayer extends StatefulWidget {
   final TileUpdateTransformer tileUpdateTransformer;
 
   /// Defines the minimum delay time from last map event before the tile layers are updated.
-  /// 
+  ///
   /// 16ms could be a good starting point for most applications. This at 60fps this will wait one frame after the last event.
   ///
   /// This delay acts as a debounce period to prevent frequent reloading of tile layers in response to rapid, successive events (e.g., zooming or panning).
@@ -218,7 +218,7 @@ class TileLayer extends StatefulWidget {
   /// By setting this delay, we ensure that map layer updates are performed only after a period of inactivity, enhancing performance and user experience on lower performance devices.
   ///
   /// - If multiple events occur within this delay period, only the last event triggers the tile layer update, reducing unnecessary processing and network requests.
-  /// 
+  ///
   /// - If the [loadingDelay] is `null`, the tile layers will update as soon as possible.
   final Duration? loadingDelay;
 
@@ -362,9 +362,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     _loadAndPruneInVisibleBounds(MapCamera.of(context));
   });
 
-  
-
-/// Delay Timer for loadingDelay
+  /// Delay Timer for loadingDelay
   Timer? _delayTimer;
 
   /// This method is used to delay the execution of a function by the specified [loadingDelay].
@@ -374,7 +372,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     if (widget.loadingDelay == null) {
       action();
       return;
-    } 
+    }
 
     // Cancel the previous timer if it is still active
     if (_delayTimer?.isActive ?? false) {
@@ -552,7 +550,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               ),
               currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
-              placeHolder: tileImage.imageInfo == null ? TilePlaceholder() : null,
+              placeholder: !tileImage.readyToDisplay ? const TilePlaceholder() : null,
               tileBuilder: widget.tileBuilder,
             ))
         .toList();

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -233,12 +233,12 @@ class TileLayer extends StatefulWidget {
   /// If `false`, no placeholder grid will be shown.
   /// If `true` and [placeholder] is not set, a default grid will be shown.
   /// If `true` and [placeholder] is set, the [placeholder] will be shown instead.
-  final bool showPlaceholderGrid;
+  final bool showPlaceholder;
 
   ///An optional widget to be shown while the tile is loading
-  ///[showPlaceholderGrid] should be set to true, to see the placeholder.
-  ///If [showPlaceholderGrid] is set to false, this widget will not be shown.
-  ///If the [showPlaceholderGrid] is set to true and this widget is not set, a default grid will be shown.
+  ///[showPlaceholder] should be set to true, to see the placeholder.
+  ///If [showPlaceholder] is set to false, this widget will not be shown.
+  ///If the [showPlaceholder] is set to true and this widget is not set, a default grid will be shown.
   final Widget? placeholder;
 
   /// Create a new [TileLayer] for the [FlutterMap] widget.
@@ -274,7 +274,7 @@ class TileLayer extends StatefulWidget {
     this.tileBounds,
     this.loadingDelay = Duration.zero,
     TileUpdateTransformer? tileUpdateTransformer,
-    this.showPlaceholderGrid = false,
+    this.showPlaceholder = false,
     this.placeholder,
     String userAgentPackageName = 'unknown',
   })  : assert(
@@ -569,7 +569,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               ),
               currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
-              placeholder: widget.showPlaceholderGrid ? widget.placeholder ?? const TilePlaceholder() : null,
+              placeholder: widget.showPlaceholder ? widget.placeholder ?? const TilePlaceholder() : null,
               tileBuilder: widget.tileBuilder,
             ))
         .toList();

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -228,6 +228,10 @@ class TileLayer extends StatefulWidget {
   /// disabled and the tile layer will update as soon as possible.
   final Duration loadingDelay;
 
+  /// If `true`, a placeholder grid will be shown on the tiles that are loading.
+  /// It helps with indication of the tile loading process and in case when no tiles are loaded can indicate that app is responsive rather than see a blank gay screen.
+  final bool showPlaceholderGrid;
+
   /// Create a new [TileLayer] for the [FlutterMap] widget.
   TileLayer({
     super.key,
@@ -261,6 +265,7 @@ class TileLayer extends StatefulWidget {
     this.tileBounds,
     this.loadingDelay = Duration.zero,
     TileUpdateTransformer? tileUpdateTransformer,
+    this.showPlaceholderGrid = false,
     String userAgentPackageName = 'unknown',
   })  : assert(
           tileDisplay.when(
@@ -554,7 +559,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               ),
               currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
-              placeholder: const TilePlaceholder(),
+              placeholder: widget.showPlaceholderGrid ? const TilePlaceholder() : null,
               tileBuilder: widget.tileBuilder,
             ))
         .toList();

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -230,7 +230,16 @@ class TileLayer extends StatefulWidget {
 
   /// If `true`, a placeholder grid will be shown on the tiles that are loading.
   /// It helps with indication of the tile loading process and in case when no tiles are loaded can indicate that app is responsive rather than see a blank gay screen.
+  /// If `false`, no placeholder grid will be shown.
+  /// If `true` and [placeholder] is not set, a default grid will be shown.
+  /// If `true` and [placeholder] is set, the [placeholder] will be shown instead.
   final bool showPlaceholderGrid;
+
+  ///An optional widget to be shown while the tile is loading
+  ///[showPlaceholderGrid] should be set to true, to see the placeholder.
+  ///If [showPlaceholderGrid] is set to false, this widget will not be shown.
+  ///If the [showPlaceholderGrid] is set to true and this widget is not set, a default grid will be shown.
+  final Widget? placeholder;
 
   /// Create a new [TileLayer] for the [FlutterMap] widget.
   TileLayer({
@@ -266,6 +275,7 @@ class TileLayer extends StatefulWidget {
     this.loadingDelay = Duration.zero,
     TileUpdateTransformer? tileUpdateTransformer,
     this.showPlaceholderGrid = false,
+    this.placeholder,
     String userAgentPackageName = 'unknown',
   })  : assert(
           tileDisplay.when(
@@ -559,7 +569,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               ),
               currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
-              placeholder: widget.showPlaceholderGrid ? const TilePlaceholder() : null,
+              placeholder: widget.showPlaceholderGrid ? widget.placeholder ?? const TilePlaceholder() : null,
               tileBuilder: widget.tileBuilder,
             ))
         .toList();


### PR DESCRIPTION
Summary:
This update introduces customizable loading placeholders for the Tile widget, offering both a default grid and the option to use a custom widget as a placeholder. The feature is controlled by the showPlaceholder boolean parameter within TileLayer. When showPlaceholder is true, developers can either rely on the default grid or specify their own widget to be displayed during tile loading. This addition significantly improves the app's visual feedback during slow loading times.

Key Changes:

showPlaceholder Parameter: Determines whether any placeholder is shown during tile loading. A false value results in no placeholder, maintaining a clean but potentially empty tile space during load.
Custom Placeholder Widget: When showPlaceholder is true, and a custom widget is provided via the placeholder parameter, this widget will be displayed as the loading indicator. This allows for unique, app-specific loading visuals.
Default Grid Placeholder: In the absence of a custom widget (with showPlaceholder set to true), a default grid serves as the loading indicator, enhancing the user's awareness of the loading process without overwhelming the visual experience.

Benefits:
Improved User Experience: Offers immediate visual feedback during tile loading, enhancing the perception of responsiveness, especially in low bandwidth scenarios.
Flexibility and Customization: Developers can customize tile loading experiance wih custom placeholders. 