### PR TITLE
Add placeholder support for tile loading

### DIFF
--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
-import 'tile_placeholder_painter.dart';
+import 'package:flutter_map/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart';
 
+/// A placeholder widget for unloaded tile images.
 class TilePlaceholder extends StatelessWidget {
+  /// A placeholder widget for unloaded tile images.
   const TilePlaceholder({super.key});
 
   @override

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+import 'tile_placeholder_painter.dart';
+
+class TilePlaceholder extends StatelessWidget {
+  const TilePlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const LimitedBox(
+      maxWidth: 400,
+      maxHeight: 400,
+      child: CustomPaint(
+        size: Size.infinite,
+        painter: TilePlaceholderPainter(
+          color: Colors.white,
+          strokeWidth: 1,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
@@ -17,6 +17,7 @@ class TilePlaceholderPainter extends CustomPainter {
   ///The width of the grid lines
   final double strokeWidth;
 
+  ///Draws grid lines on the tile. First and last lines are drawn with a thicker stroke width to better visualize the tile boundaries.
   void _drawGrid(Canvas canvas, Size size) {
     final Paint paint = Paint()
       ..color = color.withOpacity(0.1)
@@ -48,8 +49,8 @@ class TilePlaceholderPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(TilePlaceholderPainter oldPainter) {
-    return oldPainter.color != color || oldPainter.strokeWidth != strokeWidth;
+  bool shouldRepaint(TilePlaceholderPainter oldDelegate) {
+    return oldDelegate.color != color || oldDelegate.strokeWidth != strokeWidth;
   }
 
   @override

--- a/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
+++ b/lib/src/layer/tile_layer/placeholder/tile_placeholder_painter.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+///Draws a Rectangular grid lines on the tile
+class TilePlaceholderPainter extends CustomPainter {
+  /// Creates a TilePlaceholderPainter.
+  ///
+  /// The [color] parameter specifies the color of the grid lines.
+  /// The [strokeWidth] parameter specifies the width of the grid lines.
+  const TilePlaceholderPainter({
+    required this.color,
+    required this.strokeWidth,
+  });
+
+  ///The color of the grid lines
+  final Color color;
+
+  ///The width of the grid lines
+  final double strokeWidth;
+
+  void _drawGrid(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = color.withOpacity(0.1)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth;
+    for (double i = 0; i <= size.width; i += size.width / 9) {
+      if (i == 0 || i >= size.width) {
+        canvas.drawLine(Offset(i, 0), Offset(i, size.height),
+            paint..strokeWidth = strokeWidth + 2);
+      } else {
+        canvas.drawLine(Offset(i, 0), Offset(i, size.height),
+            paint..strokeWidth = strokeWidth);
+      }
+    }
+    for (double i = 0; i <= size.height; i += size.height / 9) {
+      if (i == 0 || i >= size.height) {
+        canvas.drawLine(Offset(0, i), Offset(size.width, i),
+            paint..strokeWidth = strokeWidth + 2);
+      } else {
+        canvas.drawLine(Offset(0, i), Offset(size.width, i),
+            paint..strokeWidth = strokeWidth);
+      }
+    }
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    _drawGrid(canvas, size);
+  }
+
+  @override
+  bool shouldRepaint(TilePlaceholderPainter oldPainter) {
+    return oldPainter.color != color || oldPainter.strokeWidth != strokeWidth;
+  }
+
+  @override
+  bool hitTest(Offset position) => false;
+}

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -21,6 +21,9 @@ class Tile extends StatefulWidget {
   /// visible pixel when the map is rotated.
   final Point<double> currentPixelOrigin;
 
+  ///A placeholder widget to be shown while the tile is loading
+  final Widget? placeholder;
+
   /// Creates a new instance of [Tile].
   const Tile({
     super.key,
@@ -28,6 +31,7 @@ class Tile extends StatefulWidget {
     required this.currentPixelOrigin,
     required this.tileImage,
     required this.tileBuilder,
+    this.placeholder,
   });
 
   @override
@@ -81,6 +85,9 @@ class _TileState extends State<Tile> {
             ? null
             : AlwaysStoppedAnimation(widget.tileImage.opacity),
       );
+    } else if (widget.tileImage.imageInfo == null &&
+        widget.placeholder != null) {
+      return widget.placeholder!;
     } else {
       return AnimatedBuilder(
         animation: widget.tileImage.animation!,

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart' show MapEquality;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/layer/tile_layer/placeholder/tile_placeholder.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart';
@@ -227,6 +228,21 @@ class TileLayer extends StatefulWidget {
   /// disabled and the tile layer will update as soon as possible.
   final Duration loadingDelay;
 
+  /// If `true`, a placeholder grid will be shown on the tiles that are loading.
+  /// It helps with indication of the tile loading process and in case when no tiles are loaded can indicate that app is responsive rather than see a blank gay screen.
+  /// If `false`, no placeholder grid will be shown.
+  ///
+  /// If `true` and [placeholder] is not set, a default grid will be shown.
+  ///
+  /// If `true` and [placeholder] is set, the [placeholder] will be shown instead.
+  final bool showPlaceholder;
+
+  ///An optional widget to be shown while the tile is loading
+  ///[showPlaceholder] should be set to true, to see the placeholder.
+  ///If [showPlaceholder] is set to false, this widget will not be shown.
+  ///If the [showPlaceholder] is set to true and this widget is not set, a default grid will be shown.
+  final Widget? placeholder;
+
   /// Create a new [TileLayer] for the [FlutterMap] widget.
   TileLayer({
     super.key,
@@ -261,6 +277,8 @@ class TileLayer extends StatefulWidget {
     this.loadingDelay = Duration.zero,
     TileUpdateTransformer? tileUpdateTransformer,
     String userAgentPackageName = 'unknown',
+    this.showPlaceholder = false,
+    this.placeholder,
   })  : assert(
           tileDisplay.when(
             instantaneous: (_) => true,
@@ -554,6 +572,9 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
               currentPixelOrigin: map.pixelOrigin,
               tileImage: tileImage,
               tileBuilder: widget.tileBuilder,
+              placeholder: widget.showPlaceholder
+                  ? widget.placeholder ?? const TilePlaceholder()
+                  : null,
             ))
         .toList();
 


### PR DESCRIPTION
Summary:
This update introduces customizable loading placeholders for the Tile widget, offering both a default grid and the option to use a custom widget as a placeholder. The feature is controlled by the showPlaceholder boolean parameter within TileLayer. When showPlaceholder is true, developers can either rely on the default grid or specify their own widget to be displayed during tile loading. This addition significantly improves the app's visual feedback during slow loading times.

Key Changes:

showPlaceholder Parameter: Determines whether any placeholder is shown during tile loading. A false value results in no placeholder, maintaining a clean but potentially empty tile space during load.
Custom Placeholder Widget: When showPlaceholder is true, and a custom widget is provided via the placeholder parameter, this widget will be displayed as the loading indicator. This allows for unique, app-specific loading visuals.
Default Grid Placeholder: In the absence of a custom widget (with showPlaceholder set to true), a default grid serves as the loading indicator, enhancing the user's awareness of the loading process without overwhelming the visual experience.

Benefits:
Improved User Experience: Offers immediate visual feedback during tile loading, enhancing the perception of responsiveness, especially in low bandwidth scenarios.
Flexibility and Customization: Developers can customize tile loading experiance wih custom placeholders.