### PR TITLE
Tile rendering migration to CustomPainter 

### DIFF
--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 /// The widget for a single tile used for the [TileLayer].
+@Deprecated('Use TileModel instead')
 @immutable
 class Tile extends StatefulWidget {
   /// [TileImage] is the model class that contains meta data for the Tile image.

--- a/lib/src/layer/tile_layer/tile.dart
+++ b/lib/src/layer/tile_layer/tile.dart
@@ -4,7 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 /// The widget for a single tile used for the [TileLayer].
-@Deprecated('Use TileModel instead')
+/// If proceed with the implementation of the CustomPainter and the TileModel this Widget should be removed.
 @immutable
 class Tile extends StatefulWidget {
   /// [TileImage] is the model class that contains meta data for the Tile image.

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -5,19 +5,17 @@ import 'package:collection/collection.dart' show MapEquality;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/src/layer/tile_layer/tile.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_bounds/tile_bounds_at_zoom.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_image_manager.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_model.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_painter.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_range_calculator.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_scale_calculator.dart';
 import 'package:http/http.dart';
 import 'package:http/retry.dart';
 import 'package:logger/logger.dart';
-
-import 'tile_painter.dart';
 
 part 'retina_mode.dart';
 part 'tile_error_evict_callback.dart';

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -580,9 +580,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         .getTilesToRender(visibleRange: visibleTileRange)
         .map(
           (tileImage) => TileModel(
-            // Must be an ObjectKey, not a ValueKey using the coordinates, in
-            // case we remove and replace the TileImage with a different one.
-            key: ObjectKey(tileImage),
             scaledTileSize: _tileScaleCalculator.scaledTileSize(
               map.zoom,
               tileImage.coordinates.z,

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -634,7 +634,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
             widget,
           );
 
-    return TileImage(
+    final TileImage tileImage = TileImage(
       vsync: this,
       coordinates: coordinates,
       imageProvider: imageProvider,
@@ -642,13 +642,20 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       onLoadComplete: (coordinates) {
         if (pruneAfterLoad) _pruneIfAllTilesLoaded(coordinates);
         setState(() {
-          //Refresh the widget to display the loaded tile
+          // Refresh the widget to display the loaded tile.
         });
       },
       tileDisplay: widget.tileDisplay,
       errorImage: widget.errorImage,
       cancelLoading: cancelLoading,
     );
+
+    tileImage.animation?.addListener(() {
+      setState(() {
+        //Update with fade in animation if TileDisplay.fadeIn() is used.
+      });
+    });
+    return tileImage;
   }
 
   /// Load and/or prune tiles according to the visible bounds of the [event]

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -231,7 +231,7 @@ class TileLayer extends StatefulWidget {
   final Duration loadingDelay;
 
   ///Allows to set different paint parameters that are used in CustomPainter to draw tiles.
-  ///If provided, it is recommended to set filterQuality to high.
+  ///If provided, it is recommended to set filterQuality to high. Setting isAntiAlias to true is not recommended as it may introduce ghost lines between tiles.
   ///
   ///Example: Setting a color filter to draw tiles in grayscale.
   ///```dart
@@ -258,7 +258,7 @@ class TileLayer extends StatefulWidget {
   /// If not specified, the default paint parameters are:
   /// ```dart
   /// Paint()
-  ///  ..isAntiAlias = true
+  ///  ..isAntiAlias = false
   ///  ..filterQuality = FilterQuality.high;
   /// ```
   final Paint? paint;

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -230,6 +230,39 @@ class TileLayer extends StatefulWidget {
   /// disabled and the tile layer will update as soon as possible.
   final Duration loadingDelay;
 
+  ///Allows to set different paint parameters that are used in CustomPainter to draw tiles.
+  ///If provided, it is recommended to set filterQuality to high.
+  ///
+  ///Example: Setting a color filter to draw tiles in grayscale.
+  ///```dart
+  /// paint: Paint()..colorFilter = const ColorFilter.mode(Colors.grey, BlendMode.saturation)..filterQuality = FilterQuality.high,
+  /// ```
+  ///
+  /// Example: Inverting the colors of the tiles.
+  /// ```dart
+  /// paint: Paint()..invertColors = true ..filterQuality = FilterQuality.high,
+  /// ```
+  ///
+  /// It is possible to change map colors in various ways using the ColorFilter.matrix.
+  ///
+  /// Example: Toning map with sepia color.
+  /// ```dart
+  /// paint: Paint()..colorFilter = const ColorFilter.matrix([
+  ///          0.393, 0.769, 0.189, 0, 0,
+  ///          0.349, 0.686, 0.168, 0, 0,
+  ///          0.272, 0.534, 0.131, 0, 0,
+  ///          0,     0,     0,     1, 0,
+  ///    ])..filterQuality = FilterQuality.high,
+  /// ```
+  ///
+  /// If not specified, the default paint parameters are:
+  /// ```dart
+  /// Paint()
+  ///  ..isAntiAlias = true
+  ///  ..filterQuality = FilterQuality.high;
+  /// ```
+  final Paint? paint;
+
   /// Create a new [TileLayer] for the [FlutterMap] widget.
   TileLayer({
     super.key,
@@ -262,6 +295,7 @@ class TileLayer extends StatefulWidget {
     this.reset,
     this.tileBounds,
     this.loadingDelay = Duration.zero,
+    this.paint,
     TileUpdateTransformer? tileUpdateTransformer,
     String userAgentPackageName = 'unknown',
   })  : assert(
@@ -579,7 +613,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       child: CustomPaint(
         size: Size.infinite,
         willChange: true,
-        painter: TilePainter(tiles: tiles..sort(renderOrder)),
+        painter: TilePainter(
+            tiles: tiles..sort(renderOrder), tilePaint: widget.paint),
       ),
     );
   }

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -578,18 +578,20 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     // cycles saved later on in the render pipeline.
     final tiles = _tileImageManager
         .getTilesToRender(visibleRange: visibleTileRange)
-        .map((tileImage) => TileModel(
-              // Must be an ObjectKey, not a ValueKey using the coordinates, in
-              // case we remove and replace the TileImage with a different one.
-              key: ObjectKey(tileImage),
-              scaledTileSize: _tileScaleCalculator.scaledTileSize(
-                map.zoom,
-                tileImage.coordinates.z,
-              ),
-              currentPixelOrigin: map.pixelOrigin,
-              tileImage: tileImage,
-              tileBuilder: widget.tileBuilder,
-            ))
+        .map(
+          (tileImage) => TileModel(
+            // Must be an ObjectKey, not a ValueKey using the coordinates, in
+            // case we remove and replace the TileImage with a different one.
+            key: ObjectKey(tileImage),
+            scaledTileSize: _tileScaleCalculator.scaledTileSize(
+              map.zoom,
+              tileImage.coordinates.z,
+            ),
+            currentPixelOrigin: map.pixelOrigin,
+            tileImage: tileImage,
+            tileBuilder: widget.tileBuilder,
+          ),
+        )
         .toList();
 
     // Sort in render order. In reverse:

--- a/lib/src/layer/tile_layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer/tile_layer.dart
@@ -579,9 +579,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       child: CustomPaint(
         size: Size.infinite,
         willChange: true,
-        painter: TilePainter(
-          tiles: tiles..sort(renderOrder)
-          ),
+        painter: TilePainter(tiles: tiles..sort(renderOrder)),
       ),
     );
   }

--- a/lib/src/layer/tile_layer/tile_model.dart
+++ b/lib/src/layer/tile_layer/tile_model.dart
@@ -1,9 +1,8 @@
 import 'dart:math';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/src/layer/tile_layer/tile_builder.dart';
-import 'package:flutter_map/src/layer/tile_layer/tile_image.dart';
+import 'package:flutter_map/flutter_map.dart';
 
-/// The widget for a single tile used for the [TileLayer].
+/// The model for a single tile used for the [TileLayer].
 /// This replaces the `Tile` widget in the `flutter_map` package making it deprecated.
 /// Previously the `Tile` widget was a `StatefulWidget`. That is not needed with rendering tiles in Canvas.
 class TileModel {
@@ -26,7 +25,7 @@ class TileModel {
   /// I think this is needed to keep track of the tiles and prune them when they are not needed.
   final ObjectKey key;
 
-  /// Creates a new instance of [Tile].
+  /// Creates a new instance of TileModel.
   const TileModel(
       {required this.scaledTileSize,
       required this.currentPixelOrigin,

--- a/lib/src/layer/tile_layer/tile_model.dart
+++ b/lib/src/layer/tile_layer/tile_model.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_painter.dart';
 

--- a/lib/src/layer/tile_layer/tile_model.dart
+++ b/lib/src/layer/tile_layer/tile_model.dart
@@ -1,11 +1,18 @@
 import 'dart:math';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_painter.dart';
 
-/// The model for a single tile used for the [TileLayer].
-/// This replaces the `Tile` widget in the `flutter_map` package making it deprecated.
-/// Previously the `Tile` widget was a `StatefulWidget`. That is not needed with rendering tiles in Canvas.
+/// Model for tiles displayed by [TileLayer] and [TilePainter]
 class TileModel {
+  /// Controls how this tile is replaced by another tile
+  ///
+  /// See also:
+  ///
+  ///  * [Widget.key]
+  ///  * The discussions at [Key] and [GlobalKey].
+  final ObjectKey key;
+
   /// [TileImage] is the model class that contains meta data for the Tile image.
   final TileImage tileImage;
 
@@ -21,15 +28,12 @@ class TileModel {
   /// visible pixel when the map is rotated.
   final Point<double> currentPixelOrigin;
 
-  /// The key for the tile.
-  /// I think this is needed to keep track of the tiles and prune them when they are not needed.
-  final ObjectKey key;
-
   /// Creates a new instance of TileModel.
-  const TileModel(
-      {required this.scaledTileSize,
-      required this.currentPixelOrigin,
-      required this.tileImage,
-      required this.tileBuilder,
-      required this.key});
+  const TileModel({
+    required this.key,
+    required this.scaledTileSize,
+    required this.currentPixelOrigin,
+    required this.tileImage,
+    required this.tileBuilder,
+  });
 }

--- a/lib/src/layer/tile_layer/tile_model.dart
+++ b/lib/src/layer/tile_layer/tile_model.dart
@@ -5,13 +5,6 @@ import 'package:flutter_map/src/layer/tile_layer/tile_painter.dart';
 
 /// Model for tiles displayed by [TileLayer] and [TilePainter]
 class TileModel {
-  /// Controls how this tile is replaced by another tile
-  ///
-  /// See also:
-  ///
-  ///  * [Widget.key]
-  ///  * The discussions at [Key] and [GlobalKey].
-  final ObjectKey key;
 
   /// [TileImage] is the model class that contains meta data for the Tile image.
   final TileImage tileImage;
@@ -30,10 +23,29 @@ class TileModel {
 
   /// Creates a new instance of TileModel.
   const TileModel({
-    required this.key,
     required this.scaledTileSize,
     required this.currentPixelOrigin,
     required this.tileImage,
     required this.tileBuilder,
   });
+
+  ///Equality operator for TileModel
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! TileModel) return false;
+    final TileModel otherTile = other;
+    return tileImage == otherTile.tileImage &&
+        tileBuilder == otherTile.tileBuilder &&
+        scaledTileSize == otherTile.scaledTileSize &&
+        currentPixelOrigin == otherTile.currentPixelOrigin;
+  }
+
+  ///HashCode for TileModel
+  @override
+  int get hashCode =>
+      tileImage.hashCode ^
+      tileBuilder.hashCode ^
+      scaledTileSize.hashCode ^
+      currentPixelOrigin.hashCode;
 }

--- a/lib/src/layer/tile_layer/tile_model.dart
+++ b/lib/src/layer/tile_layer/tile_model.dart
@@ -1,0 +1,36 @@
+import 'dart:math';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_builder.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_image.dart';
+
+/// The widget for a single tile used for the [TileLayer].
+/// This replaces the `Tile` widget in the `flutter_map` package making it deprecated.
+/// Previously the `Tile` widget was a `StatefulWidget`. That is not needed with rendering tiles in Canvas.
+class TileModel {
+  /// [TileImage] is the model class that contains meta data for the Tile image.
+  final TileImage tileImage;
+
+  /// The [TileBuilder] is a reference to the [TileLayer]'s
+  /// [TileLayer.tileBuilder].
+  final TileBuilder? tileBuilder;
+
+  /// The tile size for the given scale of the map.
+  final double scaledTileSize;
+
+  /// Reference to the offset of the top-left corner of the bounding rectangle
+  /// of the [MapCamera]. The origin will not equal the offset of the top-left
+  /// visible pixel when the map is rotated.
+  final Point<double> currentPixelOrigin;
+
+  /// The key for the tile.
+  /// I think this is needed to keep track of the tiles and prune them when they are not needed.
+  final ObjectKey key;
+
+  /// Creates a new instance of [Tile].
+  const TileModel(
+      {required this.scaledTileSize,
+      required this.currentPixelOrigin,
+      required this.tileImage,
+      required this.tileBuilder,
+      required this.key});
+}

--- a/lib/src/layer/tile_layer/tile_model.dart
+++ b/lib/src/layer/tile_layer/tile_model.dart
@@ -4,7 +4,6 @@ import 'package:flutter_map/src/layer/tile_layer/tile_painter.dart';
 
 /// Model for tiles displayed by [TileLayer] and [TilePainter]
 class TileModel {
-
   /// [TileImage] is the model class that contains meta data for the Tile image.
   final TileImage tileImage;
 

--- a/lib/src/layer/tile_layer/tile_painter.dart
+++ b/lib/src/layer/tile_layer/tile_painter.dart
@@ -17,7 +17,7 @@ class TilePainter extends CustomPainter {
 
   /// The default paint object.
   Paint get _defaultPaint => Paint()
-    ..isAntiAlias = true
+    ..isAntiAlias = false
     ..filterQuality = FilterQuality.high;
 
   @override

--- a/lib/src/layer/tile_layer/tile_painter.dart
+++ b/lib/src/layer/tile_layer/tile_painter.dart
@@ -1,4 +1,6 @@
 import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_model.dart';
 
@@ -7,8 +9,16 @@ class TilePainter extends CustomPainter {
   /// The list of tile models.
   List<TileModel> tiles;
 
+  ///Allows user to pass a custom paint object to the canvas.
+  final Paint? tilePaint;
+
   /// Constructs a `TilePainter` with the given list of `TileModel` objects.
-  TilePainter({required this.tiles});
+  TilePainter({required this.tiles, this.tilePaint});
+
+  /// The default paint object.
+  Paint get _defaultPaint => Paint()
+    ..isAntiAlias = true
+    ..filterQuality = FilterQuality.high;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -23,10 +33,7 @@ class TilePainter extends CustomPainter {
         final double width = tile.scaledTileSize;
         final double height = tile.scaledTileSize;
         final ui.Image image = tile.tileImage.imageInfo!.image;
-        final Paint paint = Paint();
-        paint.isAntiAlias = true;
-        paint.filterQuality = FilterQuality
-            .high; //Can be made configurable to reduce quality and get more performance.
+        final Paint paint = tilePaint ?? _defaultPaint;
         canvas.drawImageRect(
           image,
           Rect.fromLTWH(0, 0, image.width.toDouble(),

--- a/lib/src/layer/tile_layer/tile_painter.dart
+++ b/lib/src/layer/tile_layer/tile_painter.dart
@@ -49,8 +49,10 @@ class TilePainter extends CustomPainter {
             image.height.toDouble(),
           ),
           Rect.fromLTWH(left, top, width, height), // Destination rectangle
-          (tilePaint ?? defaultTilePaint)..color = 
-          (tilePaint ?? defaultTilePaint).color.withOpacity(tile.tileImage.opacity),
+          (tilePaint ?? defaultTilePaint)
+            ..color = (tilePaint ?? defaultTilePaint)
+                .color
+                .withOpacity(tile.tileImage.opacity),
         );
       }
     }

--- a/lib/src/layer/tile_layer/tile_painter.dart
+++ b/lib/src/layer/tile_layer/tile_painter.dart
@@ -1,45 +1,55 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_map/src/layer/tile_layer/tile_model.dart';
 
-///Draws the tile images on the canvas.
+/// Draws [TileModel]s onto a canvas at the correct position
 class TilePainter extends CustomPainter {
-  /// The list of tile models.
+  /// List of [TileModel]s to draw to the canvas
   List<TileModel> tiles;
 
-  ///Allows user to pass a custom paint object to the canvas.
+  /// Paint to use when drawing each tile
+  ///
+  /// Defaults to [defaultTilePaint].
   final Paint? tilePaint;
 
-  /// Constructs a `TilePainter` with the given list of `TileModel` objects.
-  TilePainter({required this.tiles, this.tilePaint});
-
-  /// The default paint object.
-  Paint get _defaultPaint => Paint()
+  /// Default [tilePaint]er
+  static Paint get defaultTilePaint => Paint()
     ..isAntiAlias = false
     ..filterQuality = FilterQuality.high;
+
+  /// Create a painter with the specified [TileModel]s and paint
+  ///
+  /// [tilePaint] indirectly defaults to [defaultTilePaint].
+  TilePainter({
+    required this.tiles,
+    this.tilePaint,
+  });
 
   @override
   void paint(Canvas canvas, Size size) {
     for (final tile in tiles) {
-      //Draw tiles if they have an image
+      // Draw tiles if they have an image
       if (tile.tileImage.imageInfo != null) {
-        //Simplify tile positions and sizes
-        final double left = tile.tileImage.coordinates.x * tile.scaledTileSize -
+        // Simplify tile positions and sizes
+        final left = tile.tileImage.coordinates.x * tile.scaledTileSize -
             tile.currentPixelOrigin.x;
-        final double top = tile.tileImage.coordinates.y * tile.scaledTileSize -
+        final top = tile.tileImage.coordinates.y * tile.scaledTileSize -
             tile.currentPixelOrigin.y;
-        final double width = tile.scaledTileSize;
-        final double height = tile.scaledTileSize;
-        final ui.Image image = tile.tileImage.imageInfo!.image;
-        final Paint paint = tilePaint ?? _defaultPaint;
+        final width = tile.scaledTileSize;
+        final height = tile.scaledTileSize;
+        final image = tile.tileImage.imageInfo!.image;
+
         canvas.drawImageRect(
           image,
-          Rect.fromLTWH(0, 0, image.width.toDouble(),
-              image.height.toDouble()), // Source rectangle
+          // Source rectangle
+          Rect.fromLTWH(
+            0,
+            0,
+            image.width.toDouble(),
+            image.height.toDouble(),
+          ),
           Rect.fromLTWH(left, top, width, height), // Destination rectangle
-          paint,
+          tilePaint ?? defaultTilePaint,
         );
       }
     }

--- a/lib/src/layer/tile_layer/tile_painter.dart
+++ b/lib/src/layer/tile_layer/tile_painter.dart
@@ -1,0 +1,45 @@
+import 'dart:ui' as ui;
+import 'package:flutter/rendering.dart';
+import 'package:flutter_map/src/layer/tile_layer/tile_model.dart';
+
+///Draws the tile images on the canvas.
+class TilePainter extends CustomPainter {
+  /// The list of tile models.
+  List<TileModel> tiles;
+
+  /// Constructs a `TilePainter` with the given list of `TileModel` objects.
+  TilePainter({required this.tiles});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    for (final tile in tiles) {
+      //Simplify tile positions and sizes
+      final double left = tile.tileImage.coordinates.x * tile.scaledTileSize -
+          tile.currentPixelOrigin.x;
+      final double top = tile.tileImage.coordinates.y * tile.scaledTileSize -
+          tile.currentPixelOrigin.y;
+      final double width = tile.scaledTileSize;
+      final double height = tile.scaledTileSize;
+      //Draw tiles if they have an image
+      if (tile.tileImage.imageInfo != null) {
+        final ui.Image image = tile.tileImage.imageInfo!.image;
+        final Paint paint = Paint();
+        paint.isAntiAlias = true;
+        paint.filterQuality = FilterQuality
+            .high; //Can be made configurable to reduce quality and get more performance.
+        canvas.drawImageRect(
+          image,
+          Rect.fromLTWH(0, 0, image.width.toDouble(),
+              image.height.toDouble()), // Source rectangle
+          Rect.fromLTWH(left, top, width, height), // Destination rectangle
+          paint,
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant TilePainter oldDelegate) {
+    return oldDelegate.tiles != tiles;
+  }
+}

--- a/lib/src/layer/tile_layer/tile_painter.dart
+++ b/lib/src/layer/tile_layer/tile_painter.dart
@@ -49,7 +49,8 @@ class TilePainter extends CustomPainter {
             image.height.toDouble(),
           ),
           Rect.fromLTWH(left, top, width, height), // Destination rectangle
-          tilePaint ?? defaultTilePaint,
+          (tilePaint ?? defaultTilePaint)..color = 
+          (tilePaint ?? defaultTilePaint).color.withOpacity(tile.tileImage.opacity),
         );
       }
     }

--- a/lib/src/layer/tile_layer/tile_painter.dart
+++ b/lib/src/layer/tile_layer/tile_painter.dart
@@ -13,15 +13,15 @@ class TilePainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     for (final tile in tiles) {
-      //Simplify tile positions and sizes
-      final double left = tile.tileImage.coordinates.x * tile.scaledTileSize -
-          tile.currentPixelOrigin.x;
-      final double top = tile.tileImage.coordinates.y * tile.scaledTileSize -
-          tile.currentPixelOrigin.y;
-      final double width = tile.scaledTileSize;
-      final double height = tile.scaledTileSize;
       //Draw tiles if they have an image
       if (tile.tileImage.imageInfo != null) {
+        //Simplify tile positions and sizes
+        final double left = tile.tileImage.coordinates.x * tile.scaledTileSize -
+            tile.currentPixelOrigin.x;
+        final double top = tile.tileImage.coordinates.y * tile.scaledTileSize -
+            tile.currentPixelOrigin.y;
+        final double width = tile.scaledTileSize;
+        final double height = tile.scaledTileSize;
         final ui.Image image = tile.tileImage.imageInfo!.image;
         final Paint paint = Paint();
         paint.isAntiAlias = true;

--- a/test/flutter_map_test.dart
+++ b/test/flutter_map_test.dart
@@ -25,7 +25,6 @@ void main() {
     await tester.pumpWidget(TestApp(markers: markers));
     expect(find.byType(FlutterMap), findsOneWidget);
     expect(find.byType(TileLayer), findsOneWidget);
-    expect(find.byType(RawImage), findsWidgets);
     expect(find.byType(MarkerLayer), findsWidgets);
     expect(find.byType(FlutterLogo), findsOneWidget);
   });


### PR DESCRIPTION
Overview
This pull request introduces a significant optimization to the map rendering process within the Flutter map. By migrating the rendering of map tiles from a Stack widget with Positioned children to a CustomPainter implementation, was achieved a remarkable improvement in performance. Initial tests demonstrate up to a 50% reduction in CPU load, leading to a smoother user experience even without the use of debouncers.

Changes Made
Map Tile Rendering: Transitioned from using Stack and Positioned widgets for displaying map tiles to drawing them directly in a CustomPainter. This approach leverages the same parameters previously used for the Stack implementation, ensuring a straightforward migration with minimal adjustments required.

Next Steps
While the initial experiment has yielded positive results, I recognize the importance of comprehensive testing and validation. The next steps will involve:

Extended Testing: Conducting a broader range of tests to validate performance improvements across various devices and use cases.
Code Review and Refinement: Get feedback from the team to refine the implementation and address any potential issues or improvements.
Documentation: Updating relevant documentation to reflect the new map rendering approach and guide future development.